### PR TITLE
Rename XTAT to ExternalTransitAccountToken

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ For now only the unauthenticated API routes are available, but more will follow.
 ### Example:
 
 Request trips, then request trip details:
+
 ```php
 <?php
 declare(strict_types=1);
@@ -40,7 +41,7 @@ $client->Authenticate(new TokenMethod($parser->parse('eyJ0eXAiOiJKV1QiLCJhbGciOi
 // Get payment cards
 $card = $client->tokens()->getPaymentCards()[0];
 // Get trips for specified Card xtat UUID 
-$trips = $client->trips()->getTrips($card->getXtat());
+$trips = $client->trips()->getTrips($card->getExternalTransitAccountToken());
 // Get last trip
 $items = $trips->getItems();
 /** @var Trip $trip */

--- a/src/Api/PassengerAccountsApi.php
+++ b/src/Api/PassengerAccountsApi.php
@@ -23,9 +23,9 @@ final class PassengerAccountsApi extends AbstractApi
         );
     }
 
-    public function deletePassengerAccount(string $paymentCardXtat): bool
+    public function deletePassengerAccount(string $cardExternalTransitAccountToken): bool
     {
-        $this->delete(sprintf('/api/v1/PassengerAccounts/%s', $paymentCardXtat));
+        $this->delete(sprintf('/api/v1/PassengerAccounts/%s', $cardExternalTransitAccountToken));
 
         return true;
     }

--- a/src/Api/PaymentApi.php
+++ b/src/Api/PaymentApi.php
@@ -9,10 +9,10 @@ use Xvilo\OVpayApi\Models\Receipt;
 
 final class PaymentApi extends AbstractApi
 {
-    public function getPayments(string $cardXtatUuid): Payments
+    public function getPayments(string $cardExternalTransitAccountToken): Payments
     {
         return $this->client->getSerializer()->deserialize(
-            $this->get(sprintf('/api/v1/Payments/%s', $cardXtatUuid), ['offset' => 0]),
+            $this->get(sprintf('/api/v1/Payments/%s', $cardExternalTransitAccountToken), ['offset' => 0]),
             Payments::class,
             'json'
         );

--- a/src/Api/TripsApi.php
+++ b/src/Api/TripsApi.php
@@ -9,10 +9,10 @@ use Xvilo\OVpayApi\Models\Trips;
 
 final class TripsApi extends AbstractApi
 {
-    public function getTrips(string $cardXtatUuid, int $offset = 0): Trips
+    public function getTrips(string $cardExternalTransitAccountToken, int $offset = 0): Trips
     {
         return $this->client->getSerializer()->deserialize(
-            $this->get(sprintf('/api/v3/Trips/%s', $cardXtatUuid), ['offset' => $offset]),
+            $this->get(sprintf('/api/v3/Trips/%s', $cardExternalTransitAccountToken), ['offset' => $offset]),
             Trips::class,
             'json'
         );

--- a/src/Models/Token.php
+++ b/src/Models/Token.php
@@ -13,7 +13,8 @@ final class Token
         private readonly string $xbot,
         private readonly string $status,
         private readonly TokenPersonalization $personalization,
-        private readonly ?string $externalTransitAccountToken = null,
+        /** xtat = External Transit Account Token */
+        private readonly ?string $xtat = null,
     ) {
     }
 
@@ -39,6 +40,6 @@ final class Token
 
     public function getExternalTransitAccountToken(): ?string
     {
-        return $this->externalTransitAccountToken;
+        return $this->xtat;
     }
 }

--- a/src/Models/Token.php
+++ b/src/Models/Token.php
@@ -13,7 +13,7 @@ final class Token
         private readonly string $xbot,
         private readonly string $status,
         private readonly TokenPersonalization $personalization,
-        private readonly ?string $xtat = null,
+        private readonly ?string $externalTransitAccountToken = null,
     ) {
     }
 
@@ -37,8 +37,8 @@ final class Token
         return $this->personalization;
     }
 
-    public function getXtat(): ?string
+    public function getExternalTransitAccountToken(): ?string
     {
-        return $this->xtat;
+        return $this->externalTransitAccountToken;
     }
 }

--- a/tests/Functional/Api/TokensApiTest.php
+++ b/tests/Functional/Api/TokensApiTest.php
@@ -23,7 +23,7 @@ final class TokensApiTest extends TestCase
         self::assertCount(1, $result);
         self::assertIsString($result[0]->getXbot());
         self::assertIsString($result[0]->getMediumType());
-        self::assertIsString($result[0]->getXtat());
+        self::assertIsString($result[0]->getExternalTransitAccountToken());
         self::assertIsString($result[0]->getStatus());
 
         $tokenPersonalization = $result[0]->getPersonalization();


### PR DESCRIPTION
- xTAT External Transit Account Token 
    - De External Transit Account Token xTAT is een afgeleide van de Transit Account dat in het GBO wordt gebruikt. 

Source used and documented https://developer.translink.nl/content/support/begrippenlijst/xtat/